### PR TITLE
Shorten 'Supprimer la zone' to bypass css bug :P

### DIFF
--- a/views/sidebar.tt
+++ b/views/sidebar.tt
@@ -41,7 +41,7 @@
                         class="btn btn-danger btn-lg"
                         data-toggle="modal"
                         data-target="#suppressionZoneModal">
-                    Supprimer la zone
+                    Supprimer
                 </button>
 
                 <!-- Modal -->


### PR DESCRIPTION
On small screens, there's a small CSS bug when editing the zone : 
![2017-08-05-181135_1366x768_scrot](https://user-images.githubusercontent.com/4533074/28996968-b59afc72-7a0a-11e7-8f08-6e2c2b89c090.png)

Not a CSS expert, but a way to bypass the bug is to shorten the string to simply 'Supprimer'
